### PR TITLE
Use amazonlinux:2 base image

### DIFF
--- a/Dockerfile.wxp32-ie6
+++ b/Dockerfile.wxp32-ie6
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 
 LABEL maintainer="art.sormy@gmail.com"
 

--- a/Dockerfile.wxp32-ie7
+++ b/Dockerfile.wxp32-ie7
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 
 LABEL maintainer="art.sormy@gmail.com"
 

--- a/Dockerfile.wxp32-ie8
+++ b/Dockerfile.wxp32-ie8
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 
 LABEL maintainer="art.sormy@gmail.com"
 

--- a/Dockerfile.wxp64-ie6
+++ b/Dockerfile.wxp64-ie6
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 
 LABEL maintainer="art.sormy@gmail.com"
 

--- a/Dockerfile.wxp64-ie6-64
+++ b/Dockerfile.wxp64-ie6-64
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 
 LABEL maintainer="art.sormy@gmail.com"
 

--- a/Dockerfile.wxp64-ie7
+++ b/Dockerfile.wxp64-ie7
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 
 LABEL maintainer="art.sormy@gmail.com"
 

--- a/Dockerfile.wxp64-ie7-64
+++ b/Dockerfile.wxp64-ie7-64
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 
 LABEL maintainer="art.sormy@gmail.com"
 

--- a/Dockerfile.wxp64-ie8
+++ b/Dockerfile.wxp64-ie8
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 
 LABEL maintainer="art.sormy@gmail.com"
 

--- a/Dockerfile.wxp64-ie8-64
+++ b/Dockerfile.wxp64-ie8-64
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 
 LABEL maintainer="art.sormy@gmail.com"
 

--- a/local-configure.sh
+++ b/local-configure.sh
@@ -97,7 +97,7 @@ EOF
 cat Dockerfile.$PROFILE \
   | sed -e '/^ARG WIN_ISO_FILE=/,/RUN rm -f install\.iso/d' \
         -e '/^COPY support\/start-node/a COPY system.qcow2 .' \
-        -e 's/^FROM .*$/FROM amazonlinux/g' \
+        -e 's/^FROM .*$/FROM amazonlinux:2/g' \
         -e '/RUN \[ -n "\$PRODUCT_KEY" \]/d' \
   >> local-build.$PROFILE.docker
 


### PR DESCRIPTION
Fix dependency issue by pinning the amazonlinux base image version

```
14.20 + yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
14.36 Last metadata expiration check: 0:00:07 ago on Sun Dec 24 02:47:46 2023.
14.61 epel-release-latest-7.noarch.rpm                 62 kB/s |  15 kB     00:00
14.70 Error:
14.70  Problem: conflicting requests
14.70   - nothing provides redhat-release >= 7 needed by epel-release-7-14.noarch
14.70 (try to add '--skip-broken' to skip uninstallable packages)
```